### PR TITLE
Add support for versioned x86_64 arches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ override EFI_ESP_ROOT=/boot/efi
 endif
 EFI_ARCHES	?= $(call get-config,arches)
 ifeq ($(EFI_ARCHES),)
-override EFI_ARCHES="x86_64 aarch64 %{arm} %{ix86}"
+override EFI_ARCHES="%{x86_64} aarch64 %{arm} %{ix86}"
 endif
 EFI_VENDOR	?= $(call get-config,vendor)
 

--- a/efi-rpm-macros.spec.in
+++ b/efi-rpm-macros.spec.in
@@ -36,7 +36,7 @@ machine bootloaders and tools.
 %autosetup -S git_am -n %{name}-@@EFI_SOURCE_VERSION@@
 git config --local --add efi.vendor "%{_efi_vendor_}"
 git config --local --add efi.esp-root /boot/efi
-git config --local --add efi.arches "x86_64 aarch64 %{arm} %{ix86}"
+git config --local --add efi.arches "%{x86_64} aarch64 %{arm} %{ix86}"
 
 %build
 %make_build clean all

--- a/macros.efi-srpm.in
+++ b/macros.efi-srpm.in
@@ -29,7 +29,7 @@
   local function getarch()
     if arch("ia64") then
       return("ia64")
-    elseif arch("x86_64") then
+    elseif arch("%{x86_64}") then
       return("x64")
     elseif arch("%{ix86}") then
       return("ia32")


### PR DESCRIPTION
Recently Red Hat introduced versioned x86_64 arches support in RPM: `x86_64_v2` `x86_64_v3` `x86_64_v4`.
In terms of RPM macros they are different to `x86_64` and should be specifically mentioned in ifarch-like conditions.

Hopefully, since Fedora 39 and CS10 there is `%{x86_64}` macro available:
```
# rpm --eval %{x86_64}
x86_64 x86_64_v2 x86_64_v3 x86_64_v4 amd64 em64t
```
This PR adds versioned x86_64 arches support by replacing `x86_64` with `%{x86_64}` where necessary.

But this should be only considered if no more major efi-rpm-macros updates expected in Fedora 38 and RHEL/CS 8/9.
If they are expected then different approach is necessary.